### PR TITLE
Not using absolute URLs for HTTP requests

### DIFF
--- a/src/asyncHTTPrequest.cpp
+++ b/src/asyncHTTPrequest.cpp
@@ -311,11 +311,6 @@ bool   asyncHTTPrequest::_buildRequest(){
     _request->write(_URL->path);
     _request->write(_URL->query);
     _request->write(" HTTP/1.1\r\n");
-    _request->write("Host: ");
-    _request->write(_URL->host);
-    _request->write(":");
-    _request->write(_URL->port);
-    _request->write("\r\n");
     delete _URL;
     _URL = nullptr;
     header* hdr = _headers;

--- a/src/asyncHTTPrequest.cpp
+++ b/src/asyncHTTPrequest.cpp
@@ -308,11 +308,14 @@ bool   asyncHTTPrequest::_buildRequest(){
 
     if( ! _request) _request = new xbuf;
     _request->write(_HTTPmethod == HTTPmethodGET ? "GET " : "POST ");
-    _request->write(_URL->scheme);
-    _request->write(_URL->host);
     _request->write(_URL->path);
     _request->write(_URL->query);
     _request->write(" HTTP/1.1\r\n");
+    _request->write("Host: ");
+    _request->write(_URL->host);
+    _request->write(":");
+    _request->write(_URL->port);
+    _request->write("\r\n");
     delete _URL;
     _URL = nullptr;
     header* hdr = _headers;


### PR DESCRIPTION
The request was sent like this:
```
GET http://myserver.tld/path?query HTTP/1.1
```

However, this is very uncommon and not recommended. In fact I have seen some problems with some HTTP servers and especially PHP handling requests like this. Looking at the HTTP protocol spec I found this:

> The absoluteURI form is only allowed when the request is being made to a proxy. The most common form of Request-URI is that used to identify a resource on an origin server or gateway. In this case, only the absolute path of the URI is transmitted.

So, in this PR, I am changing the implementation, so the request from above looks like this: 

```
GET /path?query HTTP/1.1
Host: http://myserver.tld:80
```