### PR TITLE
Fix url parser

### DIFF
--- a/src/asyncHTTPrequest.cpp
+++ b/src/asyncHTTPrequest.cpp
@@ -86,11 +86,9 @@ bool	asyncHTTPrequest::open(const char* method, const char* URL){
         return false;
 
     if (!_parseURL(URL)) {
-        // Serial.print("JLC->Could Not parse URL\n"); //REMOVE
         return false;
     }
     if( _client && _client->connected() && (strcmp(_URL->host, _connectedHost) != 0 || _URL->port != _connectedPort)){
-        // Serial.print("JLC->Strcmp false\n"); //REMOVE
         return false;
     }
     char* hostName = new char[strlen(_URL->host)+10];


### PR DESCRIPTION
Hi
I noticed that you have a bug in the _parseUrl function which is not able to parse url's that redirect to root and dont have trailing frontslash.
Example: http://192.168.1.74 
The parser was returning false when calling with this string.
For it to parse you would have to call it with:  http://192.168.1.74/
First i was just adding a frontslash if it was missing but other problems came up. This fixes it.
Maybe i left some unnecessary logs over there but works now.
Anyway, great job with this library :)